### PR TITLE
Fix returning error for accepting disputes

### DIFF
--- a/dispute_gateway.go
+++ b/dispute_gateway.go
@@ -101,7 +101,7 @@ func (g *DisputeGateway) RemoveEvidence(ctx context.Context, disputeID string, e
 func (g *DisputeGateway) Accept(ctx context.Context, disputeID string) error {
 	resp, err := g.executeVersion(ctx, "PUT", "disputes/"+disputeID+"/accept", nil, apiVersion4)
 	if err != nil {
-		return nil
+		return err
 	}
 	switch resp.StatusCode {
 	case 200:


### PR DESCRIPTION
Accept should return all errors transparently exactly like other methods of the DisputeGateway.